### PR TITLE
passwordが5文字以下では登録できない、エラー文の数字修正

### DIFF
--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe User, type: :model do
       @user.password = '00000'
       @user.password_confirmation = '00000'
       @user.valid?
-      expect(@user.errors.full_messages).to include('Password is too short (minimum is 5 characters)') 
+      expect(@user.errors.full_messages).to include('Password is too short (minimum is 6 characters)') 
     end
   end
 end


### PR DESCRIPTION
# what
エラー文の修正

# why
binding.pryによるエラー文が返り、正しい記述を修正