### PR TITLE
ツイート投稿の復習

### DIFF
--- a/spec/system/tweets_spec.rb
+++ b/spec/system/tweets_spec.rb
@@ -1,22 +1,24 @@
 require 'rails_helper'
 
-RSpec.describe "ツイート投稿", type: :system do
+RSpec.describe 'ツイート投稿', type: :system do
   before do
     @user = FactoryBot.create(:user)
     @tweet_text = Faker::Lorem.sentence
     @tweet_image = Faker::Lorem.sentence
   end
-  context 'ツイート投稿ができるとき' do
-    it 'ログインしたユーザーは新規登録ができる' do
+  context 'ツイート投稿ができるとき'do
+    it 'ログインしたユーザーは新規投稿できる' do
       # ログインする
+      binding.pry
       visit user_session_path
       fill_in "Email",with:@user.email
       fill_in "Password",with:@user.password
       find('input[name="commit"]').click
       expect(current_path).to eq(root_path)
+
       # 新規投稿ページへのリンクがあることを確認する
       expect(page).to have_content('投稿する')
-
+      
       # 投稿ページに移動する
       visit new_tweet_path
 
@@ -27,7 +29,7 @@ RSpec.describe "ツイート投稿", type: :system do
       # 送信するとTweetモデルのカウントが1上がることを確認する
       expect{
         find('input[name="commit"]').click
-      }.to change {Tweet.count}.by(1)
+      }.to change { Tweet.count }.by(1)
 
       # 投稿完了ページに遷移することを確認する
       expect(current_path).to eq(tweets_path)
@@ -40,19 +42,19 @@ RSpec.describe "ツイート投稿", type: :system do
 
       # トップページには先ほど投稿した内容のツイートが存在することを確認する（画像）
       expect(page).to have_selector ".content_post[style='background-image: url(#{@tweet_image});']"
-      #have_selector:指定したセレクタが存在するか判断するマッチャ
 
       # トップページには先ほど投稿した内容のツイートが存在することを確認する（テキスト）
       expect(page).to have_content(@tweet_text)
     end
   end
-  context 'ツイート投稿ができないとき' do
-    it 'ログインしてないと新規投稿ページ遷移できない' do
+  context 'ツイート投稿ができないとき'do
+    it 'ログインしていないと新規投稿ページに遷移できない' do
       # トップページに遷移する
       visit root_path
 
       # 新規投稿ページへのリンクがない
       expect(page).to have_no_content('投稿する')
+
     end
   end
 end


### PR DESCRIPTION
#what
ツイートができる時
　ログインしたユーザーは新規投稿できる

ツイートができないとき
　ログインしていないと新規投稿ページに遷移できない

# why
勉強時間の確保が難しいので30分だけでも復習するため写経を実施。